### PR TITLE
Introduce a task that flags projects with a lot of CVE vulnerabilities

### DIFF
--- a/thoth/prescriptions_refresh/cli.py
+++ b/thoth/prescriptions_refresh/cli.py
@@ -156,4 +156,11 @@ def scorecards() -> None:
         handlers.scorecards(prescriptions)
 
 
+@cli.command("cve-warning")
+def cve_warning() -> None:
+    """Warn if projects are known to have a lot of vulnerabilities.."""
+    with Prescriptions() as prescriptions:
+        handlers.cve_warning(prescriptions)
+
+
 __name__ == "__main__" and cli()

--- a/thoth/prescriptions_refresh/handlers/__init__.py
+++ b/thoth/prescriptions_refresh/handlers/__init__.py
@@ -18,6 +18,7 @@
 """Thoth's handlers for prescriptions refresh job."""
 
 
+from .cve_warning import cve_warning
 from .gh_archived import gh_archived
 from .gh_contributors import gh_contributors
 from .gh_forked import gh_forked
@@ -28,6 +29,7 @@ from .gh_updated import gh_updated
 from .scorecards import scorecards
 
 __all__ = [
+    cve_warning.__name__,
     gh_archived.__name__,
     gh_contributors.__name__,
     gh_forked.__name__,

--- a/thoth/prescriptions_refresh/handlers/cve_warning.py
+++ b/thoth/prescriptions_refresh/handlers/cve_warning.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+# thoth-prescriptions-refresh
+# Copyright(C) 2021 Fridolin Pokorny
+#
+# This program is free software: you can redistribute it and / or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+"""Warn if projects are known to have a lot of vulnerabilities.."""
+
+import logging
+import os
+from typing import TYPE_CHECKING
+
+from thoth.storages import GraphDatabase
+
+if TYPE_CHECKING:
+    from thoth.prescriptions_refresh.prescriptions import Prescriptions
+
+_LOGGER = logging.getLogger(__name__)
+_CVE_WARNING_COUNT = int(os.getenv("THOTH_PRESCRIPTIONS_REFRESH_CVE_WARNING_COUNT", 3))
+_CVE_WARNING_PRESCRIPTION_NAME = "cve_warning.yaml"
+_CVE_WARNING_PRESCRIPTION_CONTENT = """\
+units:
+  wraps:
+  - name: {prescription_name}
+    type: wrap
+    should_include:
+      adviser_pipeline: true
+    match:
+      state:
+        resolved_dependencies:
+        - name: {package_name}
+    run:
+      justification:
+      - type: WARNING
+        message: >-
+          Package '{package_name}' is known to have at least {cve_warning_count} vulnerabilities reported in releases
+        link: cve_warning
+        package_name: {package_name}
+"""
+
+
+def cve_warning(prescriptions: "Prescriptions") -> None:
+    """Warn if projects are known to have a lot of vulnerabilities.."""
+    graph = GraphDatabase()
+    graph.connect()
+
+    for project_name in prescriptions.iter_projects():
+        if len(graph.get_python_cve_records_all(project_name)) >= _CVE_WARNING_COUNT:
+            prescription_name = ""
+            for part in map(str.capitalize, project_name.split("-")):
+                prescription_name += part
+            prescription_name += "CVEWarningWrap"
+
+            prescriptions.create_prescription(
+                project_name=project_name,
+                prescription_name=_CVE_WARNING_PRESCRIPTION_NAME,
+                content=_CVE_WARNING_PRESCRIPTION_CONTENT.format(
+                    package_name=project_name, prescription_name=prescription_name, cve_warning_count=_CVE_WARNING_COUNT
+                ),
+                commit_message=f"Project {project_name!r} has at least {_CVE_WARNING_COUNT} vulnerabilities reported",
+            )
+        else:
+            prescriptions.delete_prescription(
+                project_name,
+                _CVE_WARNING_PRESCRIPTION_NAME,
+                commit_message=f"Project {project_name!r} has less than {_CVE_WARNING_COUNT} vulnerabilities reported",
+                nonexisting_ok=True,
+            )


### PR DESCRIPTION
## Related Issues and Dependencies

Related: https://github.com/thoth-station/thoth-application/pull/2042
Related: https://github.com/thoth-station/storages/pull/2439
Related: https://github.com/thoth-station/thoth-station.github.io/pull/228
Related: https://github.com/thoth-station/prescriptions/pull/18522

## This introduces a breaking change

- [x] No

## Description

Projects with large number of known CVEs are flagged and users get a warning message that links to justification document with more information.
