### PR TITLE
Aggregate s2i security info and information about other container images

### DIFF
--- a/thoth/prescriptions_refresh/handlers/quay_security.py
+++ b/thoth/prescriptions_refresh/handlers/quay_security.py
@@ -58,7 +58,8 @@ _QUAY_SECURITY_JUSTIFICATION = """\
     run:
       justification:
       - type: WARNING
-        message: "{message}"
+        message: >-
+          {message}
         link: {link}
   - name: {prescription_name}QuaySecurityErrorWrap
     type: wrap
@@ -72,7 +73,8 @@ _QUAY_SECURITY_JUSTIFICATION = """\
     run:
       justification:
       - type: ERROR
-        message: "{message}"
+        message: >-
+          {message}
         link: {link}
         cve_name: {cve_name}
 """


### PR DESCRIPTION
## Related Issues and Dependencies

Fixes: https://github.com/thoth-station/prescriptions-refresh-job/issues/35
Related: https://github.com/thoth-station/prescriptions/pull/18535

## This introduces a breaking change

- [x] No

## Description

With this change, we aggregate and provide security-related information also information for s2i container images. Moreover, it is possible to configure which container images should be checked besides s2i and ps container images Thoth team provides.
