### PR TITLE
Keep datetime in the Quay security timestamp boot in metadata

### DIFF
--- a/thoth/prescriptions_refresh/handlers/quay_security.py
+++ b/thoth/prescriptions_refresh/handlers/quay_security.py
@@ -89,6 +89,8 @@ units:
   boots:
   - name: QuaySecurityTimestampInfoBoot
     type: boot
+    metadata:
+      datetime: '{datetime}'
     should_include:
       adviser_pipeline: true
       runtime_environments:


### PR DESCRIPTION
## This introduces a breaking change

- [x] No
