### PR TITLE
Add also tag part to prescription name in Quay security

### DIFF
--- a/thoth/prescriptions_refresh/handlers/quay_security.py
+++ b/thoth/prescriptions_refresh/handlers/quay_security.py
@@ -212,6 +212,8 @@ def _create_vulnerability_prescriptions(image: str, tag: str, vulnerabilities: L
     for part in map(str.capitalize, image.split("-")):
         prescription_name += part
 
+    prescription_name += "".join(c for c in tag if c.isalnum())
+
     # Remove duplicates.
     cve_seen: Set[str] = set()
     boot_units = ""


### PR DESCRIPTION
## Related Issues and Dependencies

... otherwise, some prescription names can collide.

## This introduces a breaking change

- [x] No
