### PR TITLE
Add a handler for package downloads information

### DIFF
--- a/thoth/prescriptions_refresh/cli.py
+++ b/thoth/prescriptions_refresh/cli.py
@@ -178,7 +178,7 @@ def thoth_community() -> None:
 
 
 @cli.command("pypi-downloads")
-def package_downloads() -> None:
+def pypi_downloads() -> None:
     """Compute downloads statistics for a package from PyPI."""
     with Prescriptions() as prescriptions:
         handlers.pypi_downloads(prescriptions)

--- a/thoth/prescriptions_refresh/cli.py
+++ b/thoth/prescriptions_refresh/cli.py
@@ -177,4 +177,11 @@ def thoth_community() -> None:
         handlers.thoth_community(prescriptions)
 
 
+@cli.command("package-downloads")
+def package_downloads() -> None:
+    """Compute downloads statistics for a package from PyPI."""
+    with Prescriptions() as prescriptions:
+        handlers.package_downloads(prescriptions)
+
+
 __name__ == "__main__" and cli()

--- a/thoth/prescriptions_refresh/cli.py
+++ b/thoth/prescriptions_refresh/cli.py
@@ -177,11 +177,11 @@ def thoth_community() -> None:
         handlers.thoth_community(prescriptions)
 
 
-@cli.command("package-downloads")
+@cli.command("pypi-downloads")
 def package_downloads() -> None:
     """Compute downloads statistics for a package from PyPI."""
     with Prescriptions() as prescriptions:
-        handlers.package_downloads(prescriptions)
+        handlers.pypi_downloads(prescriptions)
 
 
 __name__ == "__main__" and cli()

--- a/thoth/prescriptions_refresh/handlers/package_downloads.py
+++ b/thoth/prescriptions_refresh/handlers/package_downloads.py
@@ -35,7 +35,7 @@ if TYPE_CHECKING:
 _LOGGER = logging.getLogger(__name__)
 
 _PACKAGE_DOWNLOADS_PRESCRIPTION_NAME = "package_downloads.yaml"
-_PACKAGE_DOWNLOADS_PRESCRIPTION_CONTENT = """
+_PACKAGE_DOWNLOADS_PRESCRIPTION_CONTENT = """\
 units:
   wraps:
   - name: {prescription_name}
@@ -89,7 +89,7 @@ def _popularity_level(packages_total_downloads: Dict[str, int], package_name: st
     return downloads, percentile
 
 
-def package_downloads(prescriptions: "Prescriptions") -> None:
+def pypi_downloads(prescriptions: "Prescriptions") -> None:
     """Retrieve the number of downloads for PyPI packages"""
     _LOGGER.info("Querying number of package downloads available in BigQuery")
     client = bigquery.Client()
@@ -107,10 +107,9 @@ def package_downloads(prescriptions: "Prescriptions") -> None:
     rows = query_job.results()
     packages_downloads_dict = {}
     for row in rows:
-        if packages_downloads_dict[(row.file.project, row.file.version)] in packages_downloads_dict.keys():
-            packages_downloads_dict[(row.file.project, row.file.version)] += 1
-        else:
-            packages_downloads_dict[(row.file.project, row.file.version)] = 1
+        packages_downloads_dict[(row.file.project, row.file.version)] = (
+            packages_downloads_dict.get((row.file.project, row.file.version), 0) + 1
+        )
 
     concatenated_package_version_dict = {
         package[0] + " " + package[1]: downloads for package, downloads in packages_downloads_dict.items()

--- a/thoth/prescriptions_refresh/handlers/package_downloads.py
+++ b/thoth/prescriptions_refresh/handlers/package_downloads.py
@@ -119,10 +119,11 @@ def _downloads_to_popularity(downloads: int) -> str:
     """Return the popularity of a package according to its number of downloads"""
     if downloads < _PYPI_POPULARITY_LOW:
         return "low"
-    if downloads >= _PYPI_POPULARITY_LOW and downloads < _PYPI_POPULARITY_MODERATE:
+    if downloads < _PYPI_POPULARITY_MODERATE:
         return "moderate"
-    if downloads >= _PYPI_POPULARITY_MODERATE and downloads < _PYPI_POPULARITY_HIGH:
+    if downloads < _PYPI_POPULARITY_HIGH:
         return "high"
+    return "very high"
 
 
 def pypi_downloads(prescriptions: "Prescriptions") -> None:

--- a/thoth/prescriptions_refresh/handlers/package_downloads.py
+++ b/thoth/prescriptions_refresh/handlers/package_downloads.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+# thoth-prescriptions-refresh
+# Copyright(C) 2021 Red Hat, Inc.
+#
+# This program is free software: you can redistribute it and / or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+"""Retrieve the number of downloads from PyPI for a given package"""
+
+
+from datetime import datetime
+from google.cloud import bigquery
+import logging
+import matplotlib.pyplot as plt
+import os
+from typing import TYPE_CHECKING
+from typing import Any
+from typing import Dict
+from typing import Optional
+from typing import Tuple
+
+if TYPE_CHECKING:
+    from thoth.prescriptions_refresh.prescriptions import Prescriptions
+
+_LOGGER = logging.getLogger(__name__)
+
+_PACKAGE_DOWNLOADS_PRESCRIPTION_NAME = "package_downloads.yaml"
+_PACKAGE_DOWNLOADS_PRESCRIPTION_CONTENT = """
+units:
+  wraps:
+  - name: {prescription_name}
+    type: wrap
+    should_include:
+      adviser_pipeline: true
+    match:
+      state:
+        resolved_dependencies:
+        - name: {package_name}
+    run:
+      justification:
+      - type: INFO
+        message: Project '{package_name}' is in the top {popularity_level}% most downloaded packages on PyPI in the last six months, with {downloads_count} downloads.
+        link: {package_link}
+        package_name: {package_name}
+"""
+
+
+def _packages_total_downloads(package_downloads: Dict[Tuple[str, str], int]) -> Dict[str, int]:
+    """Compute popularity of packages given their number of downloads"""
+    project_popularity_dict = {}
+    for project, downloads in package_downloads.items():
+        if project_popularity_dict[project[0]] in project_popularity_dict.keys():
+            project_popularity_dict[project[0]] += downloads
+        else:
+            project_popularity_dict[project[0]] = downloads
+
+    return project_popularity_dict
+
+
+def _plot_statistics(
+    package_downloads: Dict[Any, int], plots_path: Optional[str] = ".", includes_versions: Optional[bool] = False
+) -> None:
+    """Plot downloads statistics for packages"""
+
+    plt.bar(package_downloads.keys(), package_downloads.values())
+    plt.suptitle("Number of downloads per package")
+    plt.xticks()
+
+    if includes_versions:
+        plt.savefig(os.path.join(plots_path, f"package_downloads_with_versions_{datetime.now()}.png"))
+    else:
+        plt.savefig(os.path.join(plots_path, f"package_downloads_{datetime.now()}.png"))
+
+
+def _popularity_level(packages_total_downloads: Dict[str, int], package_name: str) -> Tuple(str, str):
+    """Compute the popularity level of a package"""
+    downloads = sorted(list(packages_total_downloads.values()))
+    percentile = downloads.index(packages_total_downloads[package_name]) / len(downloads) * 100
+    return downloads, percentile
+
+
+def package_downloads(prescriptions: "Prescriptions") -> None:
+    """Retrieve the number of downloads for PyPI packages"""
+    _LOGGER.info("Querying number of package downloads available in BigQuery")
+    client = bigquery.Client()
+
+    query_job = client.query(
+        """
+    SELECT *
+    FROM `bigquery-public-data.pypi.file_downloads`
+    WHERE DATE(timestamp)
+        BETWEEN DATE_SUB(CURRENT_DATE(), INTERVAL 180 DAY)
+        AND CURRENT_DATE()
+    """
+    )
+
+    rows = query_job.results()
+    packages_downloads_dict = {}
+    for row in rows:
+        if packages_downloads_dict[(row.file.project, row.file.version)] in packages_downloads_dict.keys():
+            packages_downloads_dict[(row.file.project, row.file.version)] += 1
+        else:
+            packages_downloads_dict[(row.file.project, row.file.version)] = 1
+
+    concatenated_package_version_dict = {
+        package[0] + " " + package[1]: downloads for package, downloads in packages_downloads_dict.items()
+    }
+
+    _LOGGER.info("Creating plots of the number of downloads per package and per package version")
+    _plot_statistics(packages_downloads_dict)
+    _plot_statistics(concatenated_package_version_dict, includes_versions=True)
+
+    packages_total_downloads = _packages_total_downloads(packages_downloads_dict)
+    for project_name in prescriptions.iter_projects():
+        prescription_name = ""
+        for part in map(str.capitalize, project_name.split("-")):
+            prescription_name += part
+        prescription_name += "PackagePopularityWrap"
+
+        downloads_count, popularity_level = _popularity_level(packages_total_downloads)
+        package_link = os.path.join("https://pypi.org/project/", project_name)
+
+        prescriptions.create_prescription(
+            project_name=project_name,
+            prescription_name=_PACKAGE_DOWNLOADS_PRESCRIPTION_NAME,
+            content=_PACKAGE_DOWNLOADS_PRESCRIPTION_CONTENT.format(
+                package_name=project_name,
+                prescription_name=prescription_name,
+                popularity_level=popularity_level,
+                downloads_count=downloads_count,
+                package_link=package_link,
+            ),
+        )

--- a/thoth/prescriptions_refresh/handlers/pypi_downloads.py
+++ b/thoth/prescriptions_refresh/handlers/pypi_downloads.py
@@ -55,7 +55,7 @@ units:
     run:
       justification:
       - type: INFO
-        message: Project '{package_name}' is in the top {popularity_level}% most downloaded packages on PyPI in the last six months, with {downloads_count} downloads. Project versions popularity: \n {popularity_per_version_summary}
+        message: Project '{package_name}' is in the top {popularity_level}% most downloaded packages on PyPI in the last 180 days, with {downloads_count} downloads. The most downloaded package version is {most_downloaded_version} with {max_downloads} downloads.
         link: {package_link}
         package_name: {package_name}
 """
@@ -71,10 +71,11 @@ units:
       state:
         resolved_dependencies:
         - name: {package_name}
+          version: "=={package_version}"
     run:
       justification:
       - type: INFO
-        message: Project '{package_name}' version {package_version} had a {popularity_level} popularity level on PyPI in the last six months, with {downloads_count} downloads.
+        message: Project '{package_name}' version {package_version} had a {popularity_level} popularity level on PyPI in the last 180 days, with {downloads_count} downloads.
         link: {package_link}
         package_name: {package_name}
 """
@@ -176,9 +177,12 @@ def pypi_downloads(prescriptions: "Prescriptions") -> None:
             for package, downloads in packages_downloads_dict.items()
             if package[0] == project_name
         }
-        popularity_per_version_summary = ""
-        for package_version, downloads in package_versions_downloads:
-            popularity_per_version_summary += f"'{package_version[0]}' version {package_version[1]} has a {_downloads_to_popularity(downloads)} popularity with {downloads} downloads in the last six months. \n"
+        most_downloaded_version = (
+            max(package_versions_downloads, key=package_versions_downloads.get)[0]
+            + "version"
+            + max(package_versions_downloads, key=package_versions_downloads.get)[1]
+        )
+        max_downloads = max(package_versions_downloads.values())
 
         prescriptions.create_prescription(
             project_name=project_name,
@@ -189,7 +193,8 @@ def pypi_downloads(prescriptions: "Prescriptions") -> None:
                 popularity_level=popularity_level,
                 downloads_count=downloads_count,
                 package_link=package_link,
-                popularity_per_version_summary=popularity_per_version_summary,
+                most_downloaded_version=most_downloaded_version,
+                max_downloads=max_downloads,
             ),
         )
 

--- a/thoth/prescriptions_refresh/handlers/pypi_downloads.py
+++ b/thoth/prescriptions_refresh/handlers/pypi_downloads.py
@@ -166,10 +166,7 @@ def pypi_downloads(prescriptions: "Prescriptions") -> None:
 
     packages_total_downloads = _packages_total_downloads(packages_downloads_dict)
     for project_name in prescriptions.iter_projects():
-        prescription_name = ""
-        for part in map(str.capitalize, project_name.split("-")):
-            prescription_name += part
-        prescription_name += "PackagePopularityWrap"
+        prescription_name = prescriptions.get_prescription_name("PackagePopularityWrap", project_name)
 
         downloads_count, popularity_level = _popularity_level(packages_total_downloads, project_name)
         package_link = f"https://pypi.org/project/{project_name}"
@@ -197,10 +194,9 @@ def pypi_downloads(prescriptions: "Prescriptions") -> None:
         )
 
         for package_version, downloads_count in package_versions_downloads.items():
-            prescription_name_per_version = ""
-            for part in map(str.capitalize, package_version[0].split("-")):
-                prescription_name_per_version += part
-            prescription_name_per_version += f"{package_version[1]}PackagePopularityPerVersionWrap"
+            prescription_name_per_version = prescriptions.get_prescription_name(
+                f"{package_version[1]}PackagePopularityPerVersionWrap", package_version[0]
+            )
 
             prescriptions.create_prescription(
                 project_name=project_name,


### PR DESCRIPTION
## Related Issues and Dependencies

https://github.com/thoth-station/prescriptions-refresh-job/issues/61

## This introduces a breaking change

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## This Pull Request implements

Add a handler that computes popularity statistics on the number of downloads for a package on PyPI and writes prescriptions accordingly.
