### PR TITLE
Fix obtaining prescription name

### DIFF
--- a/thoth/prescriptions_refresh/handlers/gh_link.py
+++ b/thoth/prescriptions_refresh/handlers/gh_link.py
@@ -172,7 +172,7 @@ def gh_link(knowledge: "Knowledge") -> None:
     for project_name in knowledge.iter_projects():
         gh_url = _get_gh_url(project_name)
         if gh_url:
-            prescription_name = Prescriptions.get_prescription_name("GitHubURLWrap", project_name)
+            prescription_name = knowledge.prescriptions.get_prescription_name("GitHubURLWrap", project_name)
 
             prescription_content = _GH_LINK_PRESCRIPTION_CONTENT.format(
                 package_name=project_name,

--- a/thoth/prescriptions_refresh/handlers/quay_security.py
+++ b/thoth/prescriptions_refresh/handlers/quay_security.py
@@ -32,10 +32,8 @@ from typing import Set
 from typing import Tuple
 from collections import defaultdict
 from itertools import chain
-from typing import TYPE_CHECKING
 
-if TYPE_CHECKING:
-    from thoth.prescriptions_refresh.prescriptions import Prescriptions
+from thoth.prescriptions_refresh.prescriptions import Prescriptions
 
 _LOGGER = logging.getLogger(__name__)
 _QUAY_TOKEN = os.getenv("THOTH_PRESCRIPTIONS_REFRESH_QUAY_TOKEN")


### PR DESCRIPTION
## This introduces a breaking change

- [x] No

## Description

`Prescriptions` class is imported only if no `TYPE_CHECKING` is done. This causes errors in some handlers which are trying to call `Prescriptions.get_prescription_name`.
