### PR TITLE
Pass package version as a parameter to avoid any unwanted chars in name

### DIFF
--- a/thoth/prescriptions_refresh/handlers/pypi_downloads.py
+++ b/thoth/prescriptions_refresh/handlers/pypi_downloads.py
@@ -200,7 +200,7 @@ def pypi_downloads(prescriptions: "Prescriptions") -> None:
 
         for package_version, downloads_count in package_versions_downloads.items():
             prescription_name_per_version = prescriptions.get_prescription_name(
-                f"{package_version[1]}PackagePopularityPerVersionWrap", package_version[0]
+                "PackagePopularityPerVersionWrap", package_version[0], package_version[1],
             )
 
             prescriptions.create_prescription(


### PR DESCRIPTION
## This introduces a breaking change

- [x] No

## Description

`Prescriptions.get_prescription_name` escapes all the items and substitutes unwanted characters that should not be part of the prescription name. Use it to generate the prescritpion name.
