### PR TITLE
Do a local import for matplotlib

### DIFF
--- a/thoth/prescriptions_refresh/handlers/pypi_downloads.py
+++ b/thoth/prescriptions_refresh/handlers/pypi_downloads.py
@@ -21,7 +21,6 @@
 from datetime import datetime
 from google.cloud import bigquery
 import logging
-import matplotlib.pyplot as plt
 import os
 from typing import TYPE_CHECKING
 from typing import Any
@@ -97,6 +96,7 @@ def _plot_statistics(
     package_downloads: Dict[Any, int], plots_path: Optional[str] = ".", includes_versions: Optional[bool] = False
 ) -> None:
     """Plot downloads statistics for packages."""
+    import matplotlib.pyplot as plt
 
     plt.bar(package_downloads.keys(), package_downloads.values())
     plt.suptitle("Number of downloads per package")


### PR DESCRIPTION
## This introduces a breaking change

- [x] No

## Description

prescriptions-refresh-job does not requires matplotlib. As the plotting function is not run when prescriptions-refresh-job is deployed, let matplotlib be imported locally on demand.
