### PR TITLE
Artifact size is computed per package version

### DIFF
--- a/thoth/prescriptions_refresh/handlers/pypi_artifact_size.py
+++ b/thoth/prescriptions_refresh/handlers/pypi_artifact_size.py
@@ -38,7 +38,8 @@ units:
       state:
         resolved_dependencies:
         - name: {package_name}
-          index_url: "https://pypi.org/simple"
+          version: {package_version}
+          index_url: https://pypi.org/simple
     run:
       justification:
       - type: INFO


### PR DESCRIPTION
## This introduces a breaking change

- [x] No

## Description

Make sure the artifact size is reported for the matching Python package version.

Related: https://github.com/thoth-station/prescriptions-refresh-job/pull/80