### PR TITLE
Fix version range specifier for matching Python versions

### DIFF
--- a/thoth/prescriptions_refresh/handlers/pypi_artifact_size.py
+++ b/thoth/prescriptions_refresh/handlers/pypi_artifact_size.py
@@ -38,7 +38,7 @@ units:
       state:
         resolved_dependencies:
         - name: {package_name}
-          version: {package_version}
+          version: =={package_version}
           index_url: https://pypi.org/simple
     run:
       justification:


### PR DESCRIPTION
## This introduces a breaking change

- [x] No

## Description

Fix missing version range specifier.
