### PR TITLE
Avoid empty line in prescriptions computing container image alternatives

### DIFF
--- a/thoth/prescriptions_refresh/handlers/quay_security.py
+++ b/thoth/prescriptions_refresh/handlers/quay_security.py
@@ -338,7 +338,7 @@ def quay_security(prescriptions: "Prescriptions") -> None:
             prescriptions.create_prescription(
                 project_name=project_name,
                 prescription_name="quay_security_alternatives.yaml",
-                content=f"units:\n  wraps:\n\n{units_alternatives}",
+                content=f"units:\n  wraps:\n{units_alternatives}",
                 commit_message=f"Computed vulnerability-free alternatives for {image!r}",
             )
 


### PR DESCRIPTION
## This introduces a breaking change

- [x] No
