### PR TITLE
Place all Quay security warnings on images to stack info

### DIFF
--- a/thoth/prescriptions_refresh/handlers/quay/security.py
+++ b/thoth/prescriptions_refresh/handlers/quay/security.py
@@ -75,7 +75,7 @@ _QUAY_SECURITY_WRAP = """\
         base_images:
         - {image}
     run:
-      justification:
+      stack_info:
       - type: ERROR
         message: >-
           {message}


### PR DESCRIPTION
## This introduces a breaking change

- [x] No

## Description

Let's move CVE related warnings to stack info. It makes the reported information more unified.
