### PR TITLE
Fix recommendations for base container images

### DIFF
--- a/thoth/prescriptions_refresh/handlers/quay/security.py
+++ b/thoth/prescriptions_refresh/handlers/quay/security.py
@@ -210,8 +210,8 @@ def _create_alternatives_prescriptions(vulnerabilities_found: Dict[str, Dict[str
                 )
                 units += _QUAY_ALTERNATIVE_WRAP.format(
                     prescription_name=f"{prescription_name}V{i}N{j}",
-                    image=f"{image}:{vuln_tag}",
-                    image_alternative=f"{image}:{tag}",
+                    image=f"{QUAY_URL}/{QUAY_NAMESPACE_NAME}/{image}:{vuln_tag}",
+                    image_alternative=f"{QUAY_URL}/{QUAY_NAMESPACE_NAME}/{image}:{tag}",
                     link=f"https://{QUAY_URL}/repository/{QUAY_NAMESPACE_NAME}/{image}",
                 )
 


### PR DESCRIPTION
## Related Issues and Dependencies

Check [one of the prescriptions generated](https://github.com/thoth-station/prescriptions/blob/c00d70f4caa9bf93fc8ce5f29bbdc87cf99ae02b/prescriptions/_containers/s2i_minimal_notebook/quay_security_alternatives.yaml):

```yaml
units:
  wraps:
  - name: S2iMinimalNotebookV0N0QuaySecurityAlternativeWrap
    type: wrap
    should_include:
      adviser_pipeline: true
      runtime_environments:
        base_images:
        - s2i-minimal-notebook:v0.0.8
    run:
      stack_info:
      - type: INFO
        message: >-
          Consider using 's2i-minimal-notebook:v0.2.2' as vulnerability-free alternative to 's2i-minimal-notebook:v0.0.8'
        link: https://quay.io/repository/thoth-station/s2i-minimal-notebook
```

The `base_images` section and `message` do not state full qualifier for container images, but rather just image name. This causes issues as base container image used is not matched and alternatives are not computed properly.

## This introduces a breaking change

- [x] No
