### PR TITLE
Handle too many requests error (429) in `gh-*` handlers

### DIFF
--- a/thoth/prescriptions_refresh/handlers/gh_archived.py
+++ b/thoth/prescriptions_refresh/handlers/gh_archived.py
@@ -19,6 +19,7 @@
 
 import logging
 import requests
+import sys
 from typing import TYPE_CHECKING
 
 from .gh_link import iter_gh_info
@@ -64,6 +65,16 @@ def gh_archived(prescriptions: "Prescriptions") -> None:
         if response.status_code == 404:
             _LOGGER.warning("Repository %r not found", gh_link)
             continue
+
+        elif response.status_code == 429:
+            _LOGGER.error(
+                "Bad HTTP status code %s when trying to obtain information for project %r: too many requests."
+                "Exiting code with status 0.",
+                response.status_code,
+                project_name,
+            )
+            sys.exit(0)
+
         elif response.status_code != 200:
             _LOGGER.error(
                 "Bad HTTP status code %r when obtaining info using GitHub API for %r: %s",

--- a/thoth/prescriptions_refresh/handlers/gh_contributors.py
+++ b/thoth/prescriptions_refresh/handlers/gh_contributors.py
@@ -20,6 +20,7 @@
 import logging
 import os
 import requests
+import sys
 from typing import TYPE_CHECKING
 
 from .gh_link import iter_gh_info
@@ -68,6 +69,16 @@ def gh_contributors(prescriptions: "Prescriptions") -> None:
         if response.status_code == 404:
             _LOGGER.warning("Repository %r not found", gh_link)
             continue
+
+        elif response.status_code == 429:
+            _LOGGER.error(
+                "Bad HTTP status code %s when trying to obtain information for project %r: too many requests."
+                "Exiting code with status 0.",
+                response.status_code,
+                project_name,
+            )
+            sys.exit(0)
+
         elif response.status_code != 200:
             _LOGGER.error(
                 "Bad HTTP status code %r when obtaining info using GitHub API for %r: %s",

--- a/thoth/prescriptions_refresh/handlers/gh_forked.py
+++ b/thoth/prescriptions_refresh/handlers/gh_forked.py
@@ -19,6 +19,7 @@
 
 import logging
 import requests
+import sys
 from typing import TYPE_CHECKING
 
 from .gh_link import iter_gh_info
@@ -64,6 +65,16 @@ def gh_forked(prescriptions: "Prescriptions") -> None:
         if response.status_code == 404:
             _LOGGER.warning("Repository %r not found", gh_link)
             continue
+
+        elif response.status_code == 429:
+            _LOGGER.error(
+                "Bad HTTP status code %s when trying to obtain information for project %r: too many requests."
+                "Exiting code with status 0.",
+                response.status_code,
+                project_name,
+            )
+            sys.exit(0)
+
         elif response.status_code != 200:
             _LOGGER.error(
                 "Bad HTTP status code %r when obtaining info using GitHub API for %r: %s",

--- a/thoth/prescriptions_refresh/handlers/gh_link.py
+++ b/thoth/prescriptions_refresh/handlers/gh_link.py
@@ -22,6 +22,7 @@ import logging
 import requests
 import yaml
 import os
+import sys
 from urllib.parse import urlparse
 from typing import Generator
 from typing import List
@@ -121,6 +122,15 @@ def _get_gh_url(project_name: str) -> Optional[str]:
                 # Get location from headers to follow possible redirects when ownership of GH repo is transferred.
                 result: str = response.url
                 return result
+
+            elif response.status_code == 429:
+                _LOGGER.error(
+                    "Bad HTTP status code %s when trying to obtain information for project %r: too many requests."
+                    "Exiting code with status 0.",
+                    response.status_code,
+                    project_name,
+                )
+                sys.exit(0)
             else:
                 _LOGGER.debug(
                     "%r is an invalid GitHub URL based on HTTP status code %r: %s",

--- a/thoth/prescriptions_refresh/handlers/gh_popularity.py
+++ b/thoth/prescriptions_refresh/handlers/gh_popularity.py
@@ -20,6 +20,7 @@
 import logging
 import os
 import requests
+import sys
 from typing import Any
 from typing import Tuple
 from typing import Dict
@@ -90,6 +91,16 @@ def gh_popularity(prescriptions: "Prescriptions") -> None:
         if response.status_code == 404:
             _LOGGER.warning("Repository %r not found", gh_link)
             continue
+
+        elif response.status_code == 429:
+            _LOGGER.error(
+                "Bad HTTP status code %s when trying to obtain information for project %r: too many requests."
+                "Exiting code with status 0.",
+                response.status_code,
+                project_name,
+            )
+            sys.exit(0)
+
         elif response.status_code != 200:
             _LOGGER.error(
                 "Bad HTTP status code %r when obtaining info using GitHub API for %r: %s",

--- a/thoth/prescriptions_refresh/handlers/gh_release_notes.py
+++ b/thoth/prescriptions_refresh/handlers/gh_release_notes.py
@@ -19,6 +19,7 @@
 
 import logging
 import requests
+import sys
 from typing import TYPE_CHECKING
 
 from .gh_link import iter_gh_info
@@ -92,7 +93,7 @@ def gh_release_notes(prescriptions: "Prescriptions") -> None:
             )
             continue
 
-        # Try without `v' prefix.
+        # Try with `v' prefix.
         release_url = f"https://github.com/{organization}/{repository}/releases/tag/v{version}"
         try:
             response = requests.head(release_url, allow_redirects=True)
@@ -115,5 +116,14 @@ def gh_release_notes(prescriptions: "Prescriptions") -> None:
                 commit_message=f"Project {project_name!r} hosts release notes on GitHub",
             )
             continue
+
+        if response.status_code == 429:
+            _LOGGER.error(
+                "Bad HTTP status code %s when trying to obtain information for project %r: too many requests."
+                "Exiting code with status 0.",
+                response.status_code,
+                project_name,
+            )
+            sys.exit(0)
 
         _LOGGER.info("No GitHub release notes detected for %r", project_name)

--- a/thoth/prescriptions_refresh/handlers/gh_updated.py
+++ b/thoth/prescriptions_refresh/handlers/gh_updated.py
@@ -21,6 +21,7 @@ import datetime
 import logging
 import os
 import requests
+import sys
 from typing import TYPE_CHECKING
 
 from .gh_link import iter_gh_info
@@ -69,6 +70,16 @@ def gh_updated(prescriptions: "Prescriptions") -> None:
         if response.status_code == 404:
             _LOGGER.warning("Repository %r not found", gh_link)
             continue
+
+        elif response.status_code == 429:
+            _LOGGER.error(
+                "Bad HTTP status code %s when trying to obtain information for project %r: too many requests."
+                "Exiting code with status 0.",
+                response.status_code,
+                project_name,
+            )
+            sys.exit(0)
+
         elif response.status_code != 200:
             _LOGGER.error(
                 "Bad HTTP status code %r when obtaining info using GitHub API for %r: %s",


### PR DESCRIPTION
## Related Issues and Dependencies

Related to https://github.com/thoth-station/prescriptions-refresh-job/issues/130

## This introduces a breaking change

- No

## This should yield a new module release

- Yes

## This Pull Request implements

Handle `429` HTTP errors occurring when too many requests are made to the GitHub API, leading to prescriptions being wrongly deleted as the URL is recognized as invalid or non-existent. 
This change will allow the [containers running related jobs](https://github.com/thoth-station/thoth-application/blob/master/prescriptions-refresh-job/base/argo-workflows/prescriptions-refresh-gh.yaml) to exit and restart properly when the request quota for the GitHub API token in use is reached.

Another PR will be opened soon to define the `retryStrategy` for containers in the `prescription-refresh-job` workflow spec.
