### PR TITLE
Fix organization names to string in prescription template

### DIFF
--- a/thoth/prescriptions_refresh/handlers/gh_release_notes.py
+++ b/thoth/prescriptions_refresh/handlers/gh_release_notes.py
@@ -39,11 +39,11 @@ units:
     match:
       state:
         resolved_dependencies:
-        - name: {package_name}
+        - name: '{package_name}'
     run:
       release_notes:
-        organization: {organization}
-        repository: {repository}
+        organization: '{organization}'
+        repository: '{repository}'
 """
 
 


### PR DESCRIPTION
## Related Issues and Dependencies

Related to https://github.com/thoth-station/prescriptions/issues/22413

## This introduces a breaking change

- No

## This should yield a new module release

- No

## This Pull Request implements
Force string type in prescription template for organization, repository and package names.
