### PR TITLE
Revert quotes by default in release notes handler

### DIFF
--- a/thoth/prescriptions_refresh/handlers/gh_release_notes.py
+++ b/thoth/prescriptions_refresh/handlers/gh_release_notes.py
@@ -39,11 +39,11 @@ units:
     match:
       state:
         resolved_dependencies:
-        - name: '{package_name}'
+        - name: {package_name}
     run:
       release_notes:
-        organization: '{organization}'
-        repository: '{repository}'
+        organization: {organization}
+        repository: {repository}
 """
 
 


### PR DESCRIPTION
## Related Issues and Dependencies

Undoes #148, related to https://github.com/thoth-station/prescriptions/issues/22413

## This introduces a breaking change

- No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## This should yield a new module release

- No


## This Pull Request implements

This reverts #148 because it caused pre-commit's yamllint to fail on the prescriptions repository when quoting a
string value