### PR TITLE
Add prescriptions metadata in handlers

### DIFF
--- a/thoth/prescriptions_refresh/handlers/gh_archived.py
+++ b/thoth/prescriptions_refresh/handlers/gh_archived.py
@@ -20,15 +20,16 @@
 import logging
 import requests
 import sys
-from typing import TYPE_CHECKING
 
+import thoth.prescriptions_refresh
+from thoth.prescriptions_refresh.prescriptions import Prescriptions
 from .gh_link import iter_gh_info
 
 
-if TYPE_CHECKING:
-    from thoth.prescriptions_refresh.prescriptions import Prescriptions
-
 _LOGGER = logging.getLogger(__name__)
+_PRESCRIPTIONS_DEFAULT_REPO = Prescriptions.DEFAULT_PRESCRIPTIONS_REPO
+_PRESCRIPTIONS_VERSION = thoth.prescriptions_refresh.__version__
+
 _GH_LINK_PRESCRIPTION_NAME = "gh_archived.yaml"
 _GH_LINK_PRESCRIPTION_CONTENT = """\
 units:
@@ -47,6 +48,9 @@ units:
         message: Package '{package_name}' is marked as archived on GitHub
         link: {gh_link}
         package_name: {package_name}
+        metadata:
+        - prescriptions_repository: {default_prescriptions_repository}
+          prescriptions_version: {prescriptions_version}
 """
 
 
@@ -96,6 +100,8 @@ def gh_archived(prescriptions: "Prescriptions") -> None:
                     package_name=project_name,
                     prescription_name=prescription_name,
                     gh_link=gh_link,
+                    default_prescriptions_repository=_PRESCRIPTIONS_DEFAULT_REPO,
+                    prescriptions_version=_PRESCRIPTIONS_VERSION,
                 ),
                 commit_message=f"Repository for {project_name!r} is marked as archived on GitHub",
             )

--- a/thoth/prescriptions_refresh/handlers/gh_contributors.py
+++ b/thoth/prescriptions_refresh/handlers/gh_contributors.py
@@ -21,15 +21,15 @@ import logging
 import os
 import requests
 import sys
-from typing import TYPE_CHECKING
 
+import thoth.prescriptions_refresh
+from thoth.prescriptions_refresh.prescriptions import Prescriptions
 from .gh_link import iter_gh_info
 
 
-if TYPE_CHECKING:
-    from thoth.prescriptions_refresh.prescriptions import Prescriptions
-
 _LOGGER = logging.getLogger(__name__)
+_PRESCRIPTIONS_DEFAULT_REPO = Prescriptions.DEFAULT_PRESCRIPTIONS_REPO
+_PRESCRIPTIONS_VERSION = thoth.prescriptions_refresh.__version__
 
 _CONTRIBUTORS_COUNT = int(os.getenv("THOTH_PRESCRIPTIONS_REFRESH_GH_CONTRIBUTORS_COUNT", 5))
 _GH_LINK_PRESCRIPTION_NAME = "gh_contributors.yaml"
@@ -50,6 +50,9 @@ units:
         message: Package '{package_name}' has less than {contributors} contributors on GitHub
         link: {gh_link}
         package_name: {package_name}
+        metadata:
+        - prescriptions_repository: {default_prescriptions_repository}
+          prescriptions_version: {prescriptions_version}
 """
 
 
@@ -101,6 +104,8 @@ def gh_contributors(prescriptions: "Prescriptions") -> None:
                     prescription_name=prescription_name,
                     gh_link=gh_link,
                     contributors=_CONTRIBUTORS_COUNT,
+                    default_prescriptions_repository=_PRESCRIPTIONS_DEFAULT_REPO,
+                    prescriptions_version=_PRESCRIPTIONS_VERSION,
                 ),
                 commit_message=f"Project {project_name!r} has less than {_CONTRIBUTORS_COUNT} contributors on GitHub",
             )

--- a/thoth/prescriptions_refresh/handlers/gh_forked.py
+++ b/thoth/prescriptions_refresh/handlers/gh_forked.py
@@ -20,15 +20,16 @@
 import logging
 import requests
 import sys
-from typing import TYPE_CHECKING
 
+import thoth.prescriptions_refresh
+from thoth.prescriptions_refresh.prescriptions import Prescriptions
 from .gh_link import iter_gh_info
 
 
-if TYPE_CHECKING:
-    from thoth.prescriptions_refresh.prescriptions import Prescriptions
-
 _LOGGER = logging.getLogger(__name__)
+_PRESCRIPTIONS_DEFAULT_REPO = Prescriptions.DEFAULT_PRESCRIPTIONS_REPO
+_PRESCRIPTIONS_VERSION = thoth.prescriptions_refresh.__version__
+
 _GH_LINK_PRESCRIPTION_NAME = "gh_forked.yaml"
 _GH_LINK_PRESCRIPTION_CONTENT = """\
 units:
@@ -47,6 +48,9 @@ units:
         message: Package '{package_name}' is a GitHub fork
         link: {gh_link}
         package_name: {package_name}
+        metadata:
+        - prescriptions_repository: {default_prescriptions_repository}
+          prescriptions_version: {prescriptions_version}
 """
 
 
@@ -96,6 +100,8 @@ def gh_forked(prescriptions: "Prescriptions") -> None:
                     package_name=project_name,
                     prescription_name=prescription_name,
                     gh_link=gh_link,
+                    default_prescriptions_repository=_PRESCRIPTIONS_DEFAULT_REPO,
+                    prescriptions_version=_PRESCRIPTIONS_VERSION,
                 ),
                 commit_message=f"Project {project_name!r} is a fork on GitHub",
             )

--- a/thoth/prescriptions_refresh/handlers/gh_link.py
+++ b/thoth/prescriptions_refresh/handlers/gh_link.py
@@ -30,11 +30,16 @@ from typing import Optional
 from typing import Tuple
 from typing import TYPE_CHECKING
 
+import thoth.prescriptions_refresh
+from thoth.prescriptions_refresh.prescriptions import Prescriptions
+
 if TYPE_CHECKING:
     from thoth.prescriptions_refresh.knowledge import Knowledge
-    from thoth.prescriptions_refresh.prescriptions import Prescriptions
 
 _LOGGER = logging.getLogger(__name__)
+_PRESCRIPTIONS_DEFAULT_REPO = Prescriptions.DEFAULT_PRESCRIPTIONS_REPO
+_PRESCRIPTIONS_VERSION = thoth.prescriptions_refresh.__version__
+
 _GH_LINK_PRESCRIPTION_NAME = "gh_link.yaml"
 _GH_LINK_PRESCRIPTION_CONTENT = """\
 units:
@@ -53,6 +58,9 @@ units:
         message: Package '{package_name}' is hosted on GitHub
         link: {gh_url}
         package_name: {package_name}
+        metadata:
+        - prescriptions_repository: {default_prescriptions_repository}
+          prescriptions_version: {prescriptions_version}
 """
 
 
@@ -190,6 +198,8 @@ def gh_link(knowledge: "Knowledge") -> None:
                 package_name=project_name,
                 gh_url=gh_url,
                 prescription_name=prescription_name,
+                default_prescriptions_repository=_PRESCRIPTIONS_DEFAULT_REPO,
+                prescriptions_version=_PRESCRIPTIONS_VERSION,
             )
 
             knowledge.prescriptions.create_prescription(

--- a/thoth/prescriptions_refresh/handlers/gh_popularity.py
+++ b/thoth/prescriptions_refresh/handlers/gh_popularity.py
@@ -24,15 +24,16 @@ import sys
 from typing import Any
 from typing import Tuple
 from typing import Dict
-from typing import TYPE_CHECKING
 
+import thoth.prescriptions_refresh
+from thoth.prescriptions_refresh.prescriptions import Prescriptions
 from .gh_link import iter_gh_info
 
 
-if TYPE_CHECKING:
-    from thoth.prescriptions_refresh.prescriptions import Prescriptions
-
 _LOGGER = logging.getLogger(__name__)
+_PRESCRIPTIONS_DEFAULT_REPO = Prescriptions.DEFAULT_PRESCRIPTIONS_REPO
+_PRESCRIPTIONS_VERSION = thoth.prescriptions_refresh.__version__
+
 _GH_POPULARITY_LOW = int(os.getenv("THOTH_PRESCRIPTIONS_REFRESH_GH_POPULARITY_LOW", 20))
 _GH_POPULARITY_MODERATE = int(os.getenv("THOTH_PRESCRIPTIONS_REFRESH_GH_POPULARITY_MODERATE", 100))
 _GH_POPULARITY_HIGH = int(os.getenv("THOTH_PRESCRIPTIONS_REFRESH_GH_POPULARITY_HIGH", 1000))
@@ -54,6 +55,9 @@ units:
         message: Project '{package_name}' has {popularity_score} popularity on GitHub
         link: {gh_link}
         package_name: {package_name}
+        metadata:
+        - prescriptions_repository: {default_prescriptions_repository}
+          prescriptions_version: {prescriptions_version}
 """
 
 
@@ -123,6 +127,8 @@ def gh_popularity(prescriptions: "Prescriptions") -> None:
                 popularity_score=popularity_score,
                 message_type=message_type,
                 prescription_name=prescription_name,
+                default_prescriptions_repository=_PRESCRIPTIONS_DEFAULT_REPO,
+                prescriptions_version=_PRESCRIPTIONS_VERSION,
             ),
             commit_message=f"Update of GitHub popularity statistics for project {project_name!r}",
         )

--- a/thoth/prescriptions_refresh/handlers/gh_release_notes.py
+++ b/thoth/prescriptions_refresh/handlers/gh_release_notes.py
@@ -20,14 +20,16 @@
 import logging
 import requests
 import sys
-from typing import TYPE_CHECKING
 
+import thoth.prescriptions_refresh
+from thoth.prescriptions_refresh.prescriptions import Prescriptions
 from .gh_link import iter_gh_info
 
-if TYPE_CHECKING:
-    from thoth.prescriptions_refresh.prescriptions import Prescriptions
 
 _LOGGER = logging.getLogger(__name__)
+_PRESCRIPTIONS_DEFAULT_REPO = Prescriptions.DEFAULT_PRESCRIPTIONS_REPO
+_PRESCRIPTIONS_VERSION = thoth.prescriptions_refresh.__version__
+
 _GH_LINK_PRESCRIPTION_NAME = "gh_release_notes.yaml"
 _GH_LINK_PRESCRIPTION_CONTENT = """\
 units:
@@ -44,6 +46,9 @@ units:
       release_notes:
         organization: {organization}
         repository: {repository}
+        metadata:
+        - prescriptions_repository: {default_prescriptions_repository}
+          prescriptions_version: {prescriptions_version}
 """
 
 
@@ -88,6 +93,8 @@ def gh_release_notes(prescriptions: "Prescriptions") -> None:
                     package_name=project_name,
                     organization=organization,
                     repository=repository,
+                    default_prescriptions_repository=_PRESCRIPTIONS_DEFAULT_REPO,
+                    prescriptions_version=_PRESCRIPTIONS_VERSION,
                 ),
                 commit_message=f"Project {project_name!r} hosts release notes on GitHub",
             )
@@ -112,6 +119,8 @@ def gh_release_notes(prescriptions: "Prescriptions") -> None:
                     package_name=project_name,
                     organization=organization,
                     repository=repository,
+                    default_prescriptions_repository=_PRESCRIPTIONS_DEFAULT_REPO,
+                    prescriptions_version=_PRESCRIPTIONS_VERSION,
                 ),
                 commit_message=f"Project {project_name!r} hosts release notes on GitHub",
             )

--- a/thoth/prescriptions_refresh/handlers/gh_updated.py
+++ b/thoth/prescriptions_refresh/handlers/gh_updated.py
@@ -22,15 +22,16 @@ import logging
 import os
 import requests
 import sys
-from typing import TYPE_CHECKING
 
+import thoth.prescriptions_refresh
+from thoth.prescriptions_refresh.prescriptions import Prescriptions
 from .gh_link import iter_gh_info
 
 
-if TYPE_CHECKING:
-    from thoth.prescriptions_refresh.prescriptions import Prescriptions
-
 _LOGGER = logging.getLogger(__name__)
+_PRESCRIPTIONS_DEFAULT_REPO = Prescriptions.DEFAULT_PRESCRIPTIONS_REPO
+_PRESCRIPTIONS_VERSION = thoth.prescriptions_refresh.__version__
+
 _MARK_DAYS = int(os.getenv("THOTH_PRESCRIPTIONS_REFRESH_GH_UPDATED_DAYS", 365))
 _GH_LINK_PRESCRIPTION_NAME = "gh_updated.yaml"
 _GH_LINK_PRESCRIPTION_CONTENT = """\
@@ -50,6 +51,9 @@ units:
         message: Package '{package_name}' was last updated at {updated_at}
         link: {gh_link}
         package_name: {package_name}
+        metadata:
+        - prescriptions_repository: {default_prescriptions_repository}
+          prescriptions_version: {prescriptions_version}
 """
 
 
@@ -115,6 +119,8 @@ def gh_updated(prescriptions: "Prescriptions") -> None:
                 prescription_name=prescription_name,
                 gh_link=gh_link,
                 updated_at=str(commit_datetime),
+                default_prescriptions_repository=_PRESCRIPTIONS_DEFAULT_REPO,
+                prescriptions_version=_PRESCRIPTIONS_VERSION,
             ),
             commit_message=f"Project {project_name!r} was not updated for more than {_MARK_DAYS} days",
         )

--- a/thoth/prescriptions_refresh/handlers/image_analysis.py
+++ b/thoth/prescriptions_refresh/handlers/image_analysis.py
@@ -23,8 +23,8 @@ import logging
 from itertools import chain
 from typing import Dict, Any, Optional, Tuple
 
+import thoth.prescriptions_refresh
 from thoth.python import Pipfile, PipfileLock
-
 from thoth.prescriptions_refresh.prescriptions import Prescriptions
 from .quay.common import get_ps_s2i_image_names
 from .quay.common import get_image_containers
@@ -59,6 +59,9 @@ _THOTH_IMAGE_ANALYSIS_WRAP = """\
         message: >-
           Found predictive stack image that can be used with these dependencies
         link: {link}
+        metadata:
+        - prescriptions_repository: {default_prescriptions_repository}
+          prescriptions_version: {prescriptions_version}
       advised_manifest_changes:
       - file: .thoth.yaml
         patch:
@@ -219,6 +222,8 @@ def thoth_image_analysis(prescriptions: "Prescriptions") -> None:
                         image=image_url,
                         resolved_dependencies=resolved_dependencies,
                         link=image_url,
+                        default_prescriptions_repository=Prescriptions.DEFAULT_PRESCRIPTIONS_REPO,
+                        prescriptions_version=thoth.prescriptions_refresh.__version__,
                     ),
                     commit_message=f"Created prescriptions from predictable stack image: {image_url}",
                 )

--- a/thoth/prescriptions_refresh/handlers/pypi_artifact_size.py
+++ b/thoth/prescriptions_refresh/handlers/pypi_artifact_size.py
@@ -19,17 +19,19 @@
 
 import logging
 import os
-from typing import TYPE_CHECKING
 
 import requests
 from packaging.specifiers import SpecifierSet
 from thoth.storages import GraphDatabase
 from thoth.python.package_version import Version
 
-if TYPE_CHECKING:
-    from thoth.prescriptions_refresh.prescriptions import Prescriptions
+import thoth.prescriptions_refresh
+from thoth.prescriptions_refresh.prescriptions import Prescriptions
 
 _LOGGER = logging.getLogger(__name__)
+_PRESCRIPTIONS_DEFAULT_REPO = Prescriptions.DEFAULT_PRESCRIPTIONS_REPO
+_PRESCRIPTIONS_VERSION = thoth.prescriptions_refresh.__version__
+
 # Report only 3MiB+
 _PYPI_ARTIFACT_REPORT_SIZE = int(os.getenv("THOTH_PRESCRIPTIONS_REFRESH_PYPI_ARTIFACT_REPORT_SIZE", 3 * 1024 * 1024))
 _PYPI_ARTIFACT_SIZE_PRESCRIPTION_NAME = "pypi_artifact_size.yaml"
@@ -52,6 +54,9 @@ _PYPI_ARTIFACT_SIZE_PRESCRIPTION_CONTENT = """\
           '{package_version}' can have up to {artifact_size}
         link: https://pypi.org/project/{package_name}/{package_version}/#files
         package_name: {package_name}
+        metadata:
+        - prescriptions_repository: {default_prescriptions_repository}
+          prescriptions_version: {prescriptions_version}
 """
 
 
@@ -120,6 +125,8 @@ def pypi_artifact_size(prescriptions: "Prescriptions") -> None:
                     prescription_name=prescriptions.get_prescription_name(
                         "PyPIArtifactSizeWrap", project_name, package_version
                     ),
+                    default_prescriptions_repository=_PRESCRIPTIONS_DEFAULT_REPO,
+                    prescriptions_version=_PRESCRIPTIONS_VERSION,
                 )
 
         if not content:

--- a/thoth/prescriptions_refresh/handlers/pypi_downloads.py
+++ b/thoth/prescriptions_refresh/handlers/pypi_downloads.py
@@ -22,16 +22,17 @@ from datetime import datetime
 from google.cloud import bigquery
 import logging
 import os
-from typing import TYPE_CHECKING
 from typing import Any
 from typing import Dict
 from typing import Optional
 from typing import Tuple
 
-if TYPE_CHECKING:
-    from thoth.prescriptions_refresh.prescriptions import Prescriptions
+import thoth.prescriptions_refresh
+from thoth.prescriptions_refresh.prescriptions import Prescriptions
 
 _LOGGER = logging.getLogger(__name__)
+_PRESCRIPTIONS_DEFAULT_REPO = Prescriptions.DEFAULT_PRESCRIPTIONS_REPO
+_PRESCRIPTIONS_VERSION = thoth.prescriptions_refresh.__version__
 
 _PYPI_POPULARITY_LOW = int(os.getenv("THOTH_PRESCRIPTIONS_REFRESH_PYPI_POPULARITY_LOW", 20))
 _PYPI_POPULARITY_MODERATE = int(os.getenv("THOTH_PRESCRIPTIONS_REFRESH_PYPI_POPULARITY_MODERATE", 100))
@@ -61,6 +62,9 @@ units:
           The most downloaded package version is {most_downloaded_version} with {max_downloads} downloads.
         link: {package_link}
         package_name: {package_name}
+        metadata:
+        - prescriptions_repository: {default_prescriptions_repository}
+          prescriptions_version: {prescriptions_version}
 """
 _PACKAGE_DOWNLOADS_PRESCRIPTION_NAME_PER_VERSION = "pypi_downloads_per_version.yaml"
 _PACKAGE_DOWNLOADS_PER_VERSION_PRESCRIPTION_CONTENT = """\
@@ -83,6 +87,9 @@ units:
           on PyPI in the last {days} days, with {downloads_count} downloads.
         link: {package_link}
         package_name: {package_name}
+        metadata:
+        - prescriptions_repository: {default_prescriptions_repository}
+          prescriptions_version: {prescriptions_version}
 """
 
 
@@ -202,6 +209,8 @@ def pypi_downloads(prescriptions: "Prescriptions") -> None:
                 package_link=package_link,
                 most_downloaded_version=most_downloaded_version,
                 max_downloads=max_downloaded_version_downloads_count,
+                default_prescriptions_repository=_PRESCRIPTIONS_DEFAULT_REPO,
+                prescriptions_version=_PRESCRIPTIONS_VERSION,
             ),
         )
 
@@ -221,5 +230,7 @@ def pypi_downloads(prescriptions: "Prescriptions") -> None:
                     popularity_level=_downloads_to_popularity(int(version_downloads_count)),
                     downloads_count=version_downloads_count,
                     package_link=package_link,
+                    default_prescriptions_repository=_PRESCRIPTIONS_DEFAULT_REPO,
+                    prescriptions_version=_PRESCRIPTIONS_VERSION,
                 ),
             )

--- a/thoth/prescriptions_refresh/handlers/pypi_maintainers.py
+++ b/thoth/prescriptions_refresh/handlers/pypi_maintainers.py
@@ -21,7 +21,6 @@
 import logging
 import os
 import datetime
-from typing import TYPE_CHECKING
 from typing import Optional
 from typing import List
 
@@ -29,10 +28,12 @@ import requests
 from bs4 import BeautifulSoup
 from dateutil import parser as datetime_parser
 
-if TYPE_CHECKING:
-    from thoth.prescriptions_refresh.prescriptions import Prescriptions
+import thoth.prescriptions_refresh
+from thoth.prescriptions_refresh.prescriptions import Prescriptions
 
 _LOGGER = logging.getLogger(__name__)
+_PRESCRIPTIONS_DEFAULT_REPO = Prescriptions.DEFAULT_PRESCRIPTIONS_REPO
+_PRESCRIPTIONS_VERSION = thoth.prescriptions_refresh.__version__
 
 _PYPI_MAINTAINER_PROJECTS_COUNT = int(os.getenv("THOTH_PRESCRIPTIONS_REFRESH_PYPI_MAINTAINER_PROJECTS_COUNT", 3))
 _PYPI_PROJECT_MAINTAINERS_COUNT = int(os.getenv("THOTH_PRESCRIPTIONS_REFRESH_PYPI_PROJECT_MAINTAINERS_COUNT", 3))
@@ -59,6 +60,9 @@ units:
           number of projects on PyPI (less than {maintainer_projects_count})
         link: https://pypi.org/project/{package_name}/
         package_name: {package_name}
+        metadata:
+        - prescriptions_repository: {default_prescriptions_repository}
+          prescriptions_version: {prescriptions_version}
 """
 
 _PYPI_PROJECT_MAINTAINERS_PRESCRIPTION_NAME = "pypi_project_maintainers.yaml"
@@ -80,6 +84,9 @@ units:
         message: Project '{package_name}' has low number of maintainers on PyPI (less than {project_maintainers_count})
         link: https://pypi.org/project/{package_name}/
         package_name: {package_name}
+        metadata:
+        - prescriptions_repository: {default_prescriptions_repository}
+          prescriptions_version: {prescriptions_version}
 """
 
 
@@ -104,6 +111,9 @@ units:
           recently (less than {maintainers_join_days} days ago)
         link: https://pypi.org/project/{package_name}/
         package_name: {package_name}
+        metadata:
+        - prescriptions_repository: {default_prescriptions_repository}
+          prescriptions_version: {prescriptions_version}
 """
 
 
@@ -141,6 +151,8 @@ def _do_project_maintainers(prescriptions: "Prescriptions", project_name: str, m
             package_name=project_name,
             prescription_name=prescriptions.get_prescription_name("PyPIProjectMaintainersWrap", project_name),
             project_maintainers_count=_PYPI_PROJECT_MAINTAINERS_COUNT,
+            default_prescriptions_repository=_PRESCRIPTIONS_DEFAULT_REPO,
+            prescriptions_version=_PRESCRIPTIONS_VERSION,
         ),
         commit_message=f"Project {project_name!r} has less than {_PYPI_PROJECT_MAINTAINERS_COUNT} maintainers on PyPI",
     )
@@ -186,6 +198,8 @@ def _do_maintainer_projects(prescriptions: "Prescriptions", project_name: str, m
                 package_name=project_name,
                 prescription_name=prescriptions.get_prescription_name("PyPIMaintainerProjectsWrap", project_name),
                 maintainer_projects_count=_PYPI_PROJECT_MAINTAINERS_COUNT,
+                default_prescriptions_repository=_PRESCRIPTIONS_DEFAULT_REPO,
+                prescriptions_version=_PRESCRIPTIONS_VERSION,
             ),
             commit_message=f"Project {project_name!r} has no maintainer with at least "
             f"{_PYPI_MAINTAINER_PROJECTS_COUNT} projects on PyPI,",
@@ -248,6 +262,8 @@ def _do_maintainer_joined_warning(prescriptions: "Prescriptions", project_name: 
                 package_name=project_name,
                 prescription_name=prescriptions.get_prescription_name("PyPIMaintainersJoinWrap", project_name),
                 maintainers_join_days=_PYPI_MAINTAINER_JOINED_AGE_DAYS,
+                default_prescriptions_repository=_PRESCRIPTIONS_DEFAULT_REPO,
+                prescriptions_version=_PRESCRIPTIONS_VERSION,
             ),
             commit_message=f"Project {project_name!r} has maintainers who joined PyPI recently",
         )

--- a/thoth/prescriptions_refresh/handlers/pypi_release.py
+++ b/thoth/prescriptions_refresh/handlers/pypi_release.py
@@ -20,15 +20,17 @@
 import datetime
 import logging
 import os
-from typing import TYPE_CHECKING
 
 import requests
 from dateutil import parser as datetime_parser
 
-if TYPE_CHECKING:
-    from thoth.prescriptions_refresh.prescriptions import Prescriptions
+import thoth.prescriptions_refresh
+from thoth.prescriptions_refresh.prescriptions import Prescriptions
 
 _LOGGER = logging.getLogger(__name__)
+_PRESCRIPTIONS_DEFAULT_REPO = Prescriptions.DEFAULT_PRESCRIPTIONS_REPO
+_PRESCRIPTIONS_VERSION = thoth.prescriptions_refresh.__version__
+
 _PYPI_RELEASE_DAYS = int(os.getenv("THOTH_PRESCRIPTIONS_PYPI_RELEASE_DAYS", 180))
 _PYPI_RELEASE_WARNING_PRESCRIPTION_NAME = "pypi_release.yaml"
 _PYPI_RELEASE_WARNING_PRESCRIPTION_CONTENT = """\
@@ -49,6 +51,9 @@ units:
           Package '{package_name}' has no recent release, last release dates back to {last_release_datetime}
         link: https://pypi.org/project/{package_name}/#history
         package_name: {package_name}
+        metadata:
+        - prescriptions_repository: {default_prescriptions_repository}
+          prescriptions_version: {prescriptions_version}
 """
 
 
@@ -86,6 +91,8 @@ def pypi_release(prescriptions: "Prescriptions") -> None:
                     package_name=project_name,
                     prescription_name=prescriptions.get_prescription_name("PyPIReleaseWrap", project_name),
                     last_release_datetime=last_release_datetime,
+                    default_prescriptions_repository=_PRESCRIPTIONS_DEFAULT_REPO,
+                    prescriptions_version=_PRESCRIPTIONS_VERSION,
                 ),
                 commit_message=f"Project {project_name!r} has no recent releases",
             )

--- a/thoth/prescriptions_refresh/handlers/quay/image_size.py
+++ b/thoth/prescriptions_refresh/handlers/quay/image_size.py
@@ -26,9 +26,12 @@ from .common import QUAY_NAMESPACE_NAME
 from .common import QUAY_URL
 from .common import CONFIGURED_IMAGES
 
+import thoth.prescriptions_refresh
 from thoth.prescriptions_refresh.prescriptions import Prescriptions
 
 _LOGGER = logging.getLogger(__name__)
+_PRESCRIPTIONS_DEFAULT_REPO = Prescriptions.DEFAULT_PRESCRIPTIONS_REPO
+_PRESCRIPTIONS_VERSION = thoth.prescriptions_refresh.__version__
 
 _IMAGE_SIZE_PRESCRIPTION_NAME = "quay_image_size.yaml"
 _IMAGE_SIZE_BOOT = """\
@@ -45,6 +48,9 @@ _IMAGE_SIZE_BOOT = """\
         message: >-
           Container image {image!r} has a size of {size}
         link: {link}
+        metadata:
+        - prescriptions_repository: {default_prescriptions_repository}
+          prescriptions_version: {prescriptions_version}
 """
 
 
@@ -68,6 +74,8 @@ def quay_image_size(prescriptions: "Prescriptions") -> None:
                 prescription_name=prescriptions.get_prescription_name("QuayImageSizeBoot", image_name, tag),
                 link=f"https://{image_identifier}",  # Redirects to the container image listing with tag selected.
                 size=prescriptions.get_artifact_size_str(image_size),
+                default_prescriptions_repository=_PRESCRIPTIONS_DEFAULT_REPO,
+                prescriptions_version=_PRESCRIPTIONS_VERSION,
             )
 
         if not content:

--- a/thoth/prescriptions_refresh/handlers/scorecards.py
+++ b/thoth/prescriptions_refresh/handlers/scorecards.py
@@ -22,17 +22,17 @@ import os
 from typing import Any
 from typing import Dict
 
-from typing import TYPE_CHECKING
-
 from google.cloud import bigquery
 
 from .gh_link import iter_gh_info
 
-if TYPE_CHECKING:
-    from thoth.prescriptions_refresh.prescriptions import Prescriptions
+import thoth.prescriptions_refresh
+from thoth.prescriptions_refresh.prescriptions import Prescriptions
 
 
 _LOGGER = logging.getLogger(__name__)
+_PRESCRIPTIONS_DEFAULT_REPO = Prescriptions.DEFAULT_PRESCRIPTIONS_REPO
+_PRESCRIPTIONS_VERSION = thoth.prescriptions_refresh.__version__
 
 _SCORECARDS_WRAP_GENERIC_UNIT = """\
 units:
@@ -52,6 +52,9 @@ units:
         link: https://github.com/ossf/scorecard/blob/main/docs/checks.md
         package_name: {package_name}
         tag: {tag}
+        metadata:
+        - prescriptions_repository: {default_prescriptions_repository}
+          prescriptions_version: {prescriptions_version}
 """
 
 _THOTH_PRESCRIPTIONS_REFRESH_SCORECARD_FRESHNESS_WEEKS = int(
@@ -138,6 +141,8 @@ def _handle_active(
             type=justification_type,
             message=message,
             tag=f"{passed}actively-maintained",
+            default_prescriptions_repository=_PRESCRIPTIONS_DEFAULT_REPO,
+            prescriptions_version=_PRESCRIPTIONS_VERSION,
         ),
         commit_message=f"Active Security Scorecards update for {project_name!r}",
     )
@@ -309,6 +314,8 @@ def _handle_security_policy(
             type=justification_type,
             message=message,
             tag=f"{passed}security-policy",
+            default_prescriptions_repository=_PRESCRIPTIONS_DEFAULT_REPO,
+            prescriptions_version=_PRESCRIPTIONS_VERSION,
         ),
         commit_message=f"Security-Policy Security Scorecards update for {project_name!r}",
     )
@@ -351,6 +358,8 @@ def _handle_signed_releases(
             type=justification_type,
             message=message,
             tag=f"{passed}signed-releases",
+            default_prescriptions_repository=_PRESCRIPTIONS_DEFAULT_REPO,
+            prescriptions_version=_PRESCRIPTIONS_VERSION,
         ),
         commit_message=f"Signed-Releases Security Scorecards update for {project_name!r}",
     )
@@ -393,6 +402,8 @@ def _handle_signed_tags(
             type=justification_type,
             message=message,
             tag=f"{passed}cryptographically-signed",
+            default_prescriptions_repository=_PRESCRIPTIONS_DEFAULT_REPO,
+            prescriptions_version=_PRESCRIPTIONS_VERSION,
         ),
         commit_message=f"Signed-Tags Security Scorecards update for {project_name!r}",
     )
@@ -435,6 +446,8 @@ def _handle_fuzzing(
             type=justification_type,
             message=message,
             tag=f"{passed}fuzzing",
+            default_prescriptions_repository=_PRESCRIPTIONS_DEFAULT_REPO,
+            prescriptions_version=_PRESCRIPTIONS_VERSION,
         ),
         commit_message=f"Fuzzing Security Scorecards update for {project_name!r}",
     )
@@ -482,6 +495,8 @@ def _handle_vulnerabilities(
             type=justification_type,
             message=message,
             tag=f"{passed}unfixed-vulnerabilities",
+            default_prescriptions_repository=_PRESCRIPTIONS_DEFAULT_REPO,
+            prescriptions_version=_PRESCRIPTIONS_VERSION,
         ),
         commit_message=f"Vulnerabilities Security Scorecards update for {project_name!r}",
     )
@@ -524,6 +539,8 @@ def _handle_packaging(
             type=justification_type,
             message=message,
             tag=f"{passed}published-package",
+            default_prescriptions_repository=_PRESCRIPTIONS_DEFAULT_REPO,
+            prescriptions_version=_PRESCRIPTIONS_VERSION,
         ),
         commit_message=f"Packaging Security Scorecards update for {project_name!r}",
     )
@@ -566,6 +583,8 @@ def _handle_binary_artifacts(
             type=justification_type,
             message=message,
             tag=f"{passed}binary-artifacts",
+            default_prescriptions_repository=_PRESCRIPTIONS_DEFAULT_REPO,
+            prescriptions_version=_PRESCRIPTIONS_VERSION,
         ),
         commit_message=f"Binary-Artifacts Security Scorecards update for {project_name!r}",
     )
@@ -608,6 +627,8 @@ def _handle_cii_best_practices(
             type=justification_type,
             message=message,
             tag=f"{passed}cii",
+            default_prescriptions_repository=_PRESCRIPTIONS_DEFAULT_REPO,
+            prescriptions_version=_PRESCRIPTIONS_VERSION,
         ),
         commit_message=f"CII-Best-Practices Security Scorecards update for {project_name!r}",
     )
@@ -650,6 +671,8 @@ def _handle_pinned_dependencies(
             type=justification_type,
             message=message,
             tag=f"{passed}pinned-dependencies",
+            default_prescriptions_repository=_PRESCRIPTIONS_DEFAULT_REPO,
+            prescriptions_version=_PRESCRIPTIONS_VERSION,
         ),
         commit_message=f"Pinned-Dependencies Security Scorecards update for {project_name!r}",
     )
@@ -692,6 +715,8 @@ def _handle_contributors(
             type=justification_type,
             message=message,
             tag=f"{passed}multiple-companies-contributors",
+            default_prescriptions_repository=_PRESCRIPTIONS_DEFAULT_REPO,
+            prescriptions_version=_PRESCRIPTIONS_VERSION,
         ),
         commit_message=f"Contributors Security Scorecards update for {project_name!r}",
     )
@@ -734,6 +759,8 @@ def _handle_ci_tests(
             type=justification_type,
             message=message,
             tag=f"{passed}ci-tests",
+            default_prescriptions_repository=_PRESCRIPTIONS_DEFAULT_REPO,
+            prescriptions_version=_PRESCRIPTIONS_VERSION,
         ),
         commit_message=f"CI-Tests Security Scorecards update for {project_name!r}",
     )
@@ -776,6 +803,8 @@ def _handle_sast(
             type=justification_type,
             message=message,
             tag=f"{passed}static-analysis",
+            default_prescriptions_repository=_PRESCRIPTIONS_DEFAULT_REPO,
+            prescriptions_version=_PRESCRIPTIONS_VERSION,
         ),
         commit_message=f"SAST Security Scorecards update for {project_name!r}",
     )

--- a/thoth/prescriptions_refresh/handlers/thoth_community/content.py
+++ b/thoth/prescriptions_refresh/handlers/thoth_community/content.py
@@ -35,6 +35,9 @@ units:
         message: Package '{package_name}' is popular within Thoth community
         link: thoth_community
         package_name: {package_name}
+        metadata:
+        - prescriptions_repository: {default_prescriptions_repository}
+          prescriptions_version: {prescriptions_version}
 """
 
 
@@ -57,6 +60,9 @@ units:
           Consider using '{package_name}' in version '{package_version}' which is popular within Thoth community
         link: thoth_community
         package_name: {package_name}
+        metadata:
+        - prescriptions_repository: {default_prescriptions_repository}
+          prescriptions_version: {prescriptions_version}
   - name: {prescription_name}TopPackageVersionsWrap
     type: wrap
     should_include:
@@ -73,6 +79,9 @@ units:
           Package '{package_name}' in version '{package_version}' is popular within Thoth community
         link: thoth_community
         package_name: {package_name}
+        metadata:
+        - prescriptions_repository: {default_prescriptions_repository}
+          prescriptions_version: {prescriptions_version}
 """
 
 
@@ -93,6 +102,9 @@ units:
         message: Package '{package_name}' is popular as a development dependency within Thoth community
         link: thoth_community
         package_name: {package_name}
+        metadata:
+        - prescriptions_repository: {default_prescriptions_repository}
+          prescriptions_version: {prescriptions_version}
 """
 
 
@@ -116,6 +128,9 @@ units:
           as a development dependency within Thoth community
         link: thoth_community
         package_name: {package_name}
+        metadata:
+        - prescriptions_repository: {default_prescriptions_repository}
+          prescriptions_version: {prescriptions_version}
   - name: {prescription_name}TopDevPackageVersionsWrap
     type: wrap
     should_include:
@@ -133,6 +148,9 @@ units:
           within Thoth community
         link: thoth_community
         package_name: {package_name}
+        metadata:
+        - prescriptions_repository: {default_prescriptions_repository}
+          prescriptions_version: {prescriptions_version}
 """
 
 
@@ -151,6 +169,9 @@ units:
       - type: INFO
         message: Container image '{base_image}' is popular within Thoth community
         link: thoth_community
+        metadata:
+        - prescriptions_repository: {default_prescriptions_repository}
+          prescriptions_version: {prescriptions_version}
 """
 
 
@@ -169,6 +190,9 @@ units:
       - type: INFO
         message: Container image '{base_image}' in tag '{base_image_version}' is popular within Thoth community
         link: thoth_community
+        metadata:
+        - prescriptions_repository: {default_prescriptions_repository}
+          prescriptions_version: {prescriptions_version}
 """
 
 
@@ -187,6 +211,9 @@ units:
         message: >-
           Python in version '{python_version}' is popular within Thoth community
         link: thoth_community
+        metadata:
+        - prescriptions_repository: {default_prescriptions_repository}
+          prescriptions_version: {prescriptions_version}
   - name: {prescription_name}ConsiderTopPythonVersionsBoot
     type: boot
     should_include:
@@ -199,6 +226,9 @@ units:
         message: >-
           Consider switching to Python in version '{python_version}' which is popular within Thoth community
         link: thoth_community
+        metadata:
+        - prescriptions_repository: {default_prescriptions_repository}
+          prescriptions_version: {prescriptions_version}
 """
 
 
@@ -219,6 +249,9 @@ units:
           Operating system '{operating_system_name}' in version '{operating_system_version}' is
           popular within Thoth community
         link: thoth_community
+        metadata:
+        - prescriptions_repository: {default_prescriptions_repository}
+          prescriptions_version: {prescriptions_version}
 """
 
 
@@ -235,4 +268,7 @@ units:
         message: >-
           Using Thoth community statistics computed at {thoth_community_timestamp}
         link: thoth_community
+        metadata:
+        - prescriptions_repository: {default_prescriptions_repository}
+          prescriptions_version: {prescriptions_version}
 """

--- a/thoth/prescriptions_refresh/handlers/thoth_community/handler.py
+++ b/thoth/prescriptions_refresh/handlers/thoth_community/handler.py
@@ -29,10 +29,12 @@ from typing import Tuple
 from typing import TYPE_CHECKING
 
 import attr
+import thoth.prescriptions_refresh
 from thoth.common import datetime2datetime_str
 from thoth.common import map_os_name
 from thoth.common import normalize_os_version
 from thoth.prescriptions_refresh.prescriptions_change import PrescriptionsChange
+from thoth.prescriptions_refresh.prescriptions import Prescriptions
 from thoth.storages import AdvisersResultsStore
 
 from .content import PRESCRIPTION_TOP_PACKAGE_NAMES
@@ -48,10 +50,11 @@ from .content import PRESCRIPTION_THOTH_COMMUNITY_UPDATE
 
 if TYPE_CHECKING:
     from git import Repo
-    from thoth.prescriptions_refresh.prescriptions import Prescriptions
 
 
 _LOGGER = logging.getLogger(__name__)
+_PRESCRIPTIONS_DEFAULT_REPO = Prescriptions.DEFAULT_PRESCRIPTIONS_REPO
+_PRESCRIPTIONS_VERSION = thoth.prescriptions_refresh.__version__
 
 _PRESCRIPTION_NAME_PREFIX = "thoth_community"
 _DAYS = int(os.getenv("THOTH_PRESCRIPTIONS_REFRESH_THOTH_COMMUNITY_DAYS", 365 // 2))
@@ -169,6 +172,8 @@ def thoth_community(prescriptions: "Prescriptions") -> None:
             prescription = PRESCRIPTION_TOP_PACKAGE_NAMES.format(
                 prescription_name=prescriptions.get_prescription_name("", package_name),
                 package_name=package_name,
+                default_prescriptions_repository=_PRESCRIPTIONS_DEFAULT_REPO,
+                prescriptions_version=_PRESCRIPTIONS_VERSION,
             )
             change.add_prescription(package_name, f"{_PRESCRIPTION_NAME_PREFIX}_package_names.yaml", prescription)
 
@@ -178,6 +183,8 @@ def thoth_community(prescriptions: "Prescriptions") -> None:
                 prescription_name=prescriptions.get_prescription_name("", package_name, package_version),
                 package_name=package_name,
                 package_version=package_version,
+                default_prescriptions_repository=_PRESCRIPTIONS_DEFAULT_REPO,
+                prescriptions_version=_PRESCRIPTIONS_VERSION,
             )
             change.add_prescription(
                 package_name, f"{_PRESCRIPTION_NAME_PREFIX}_{package_version}_package_versions.yaml", prescription
@@ -188,6 +195,8 @@ def thoth_community(prescriptions: "Prescriptions") -> None:
             prescription = PRESCRIPTION_TOP_DEV_PACKAGE_NAMES.format(
                 prescription_name=prescriptions.get_prescription_name("", package_name),
                 package_name=package_name,
+                default_prescriptions_repository=_PRESCRIPTIONS_DEFAULT_REPO,
+                prescriptions_version=_PRESCRIPTIONS_VERSION,
             )
             change.add_prescription(package_name, f"{_PRESCRIPTION_NAME_PREFIX}_dev_package_names.yaml", prescription)
 
@@ -197,6 +206,8 @@ def thoth_community(prescriptions: "Prescriptions") -> None:
                 prescription_name=prescriptions.get_prescription_name("", package_name, package_version),
                 package_name=package_name,
                 package_version=package_version,
+                default_prescriptions_repository=_PRESCRIPTIONS_DEFAULT_REPO,
+                prescriptions_version=_PRESCRIPTIONS_VERSION,
             )
             change.add_prescription(
                 package_name, f"{_PRESCRIPTION_NAME_PREFIX}_{package_version}_dev_package_versions.yaml", prescription
@@ -208,6 +219,8 @@ def thoth_community(prescriptions: "Prescriptions") -> None:
             prescription = PRESCRIPTION_TOP_BASE_IMAGES.format(
                 prescription_name=prescriptions.get_prescription_name("", base_image_name),
                 base_image=base_image,
+                default_prescriptions_repository=_PRESCRIPTIONS_DEFAULT_REPO,
+                prescriptions_version=_PRESCRIPTIONS_VERSION,
             )
             change.add_prescription(
                 "_containers", f"{base_image_name}/{_PRESCRIPTION_NAME_PREFIX}_base_images.yaml", prescription
@@ -221,6 +234,8 @@ def thoth_community(prescriptions: "Prescriptions") -> None:
                 prescription_name=prescriptions.get_prescription_name("", base_image_name, base_image_version),
                 base_image=base_image,
                 base_image_version=base_image_version,
+                default_prescriptions_repository=_PRESCRIPTIONS_DEFAULT_REPO,
+                prescriptions_version=_PRESCRIPTIONS_VERSION,
             )
             change.add_prescription(
                 "_containers",
@@ -233,6 +248,8 @@ def thoth_community(prescriptions: "Prescriptions") -> None:
             prescription = PRESCRIPTION_TOP_PYTHON_VERSIONS.format(
                 prescription_name=prescriptions.get_prescription_name("", "Python", python_version),
                 python_version=python_version,
+                default_prescriptions_repository=_PRESCRIPTIONS_DEFAULT_REPO,
+                prescriptions_version=_PRESCRIPTIONS_VERSION,
             )
             change.add_prescription(
                 "_python",
@@ -250,6 +267,8 @@ def thoth_community(prescriptions: "Prescriptions") -> None:
                 ),
                 operating_system_name=operating_system_name,
                 operating_system_version=operating_system_version,
+                default_prescriptions_repository=_PRESCRIPTIONS_DEFAULT_REPO,
+                prescriptions_version=_PRESCRIPTIONS_VERSION,
             )
             change.add_prescription(
                 "_operating_systems",
@@ -262,5 +281,7 @@ def thoth_community(prescriptions: "Prescriptions") -> None:
             "thoth_community.yaml",
             PRESCRIPTION_THOTH_COMMUNITY_UPDATE.format(
                 thoth_community_timestamp=datetime2datetime_str(current_datetime),
+                default_prescriptions_repository=_PRESCRIPTIONS_DEFAULT_REPO,
+                prescriptions_version=_PRESCRIPTIONS_VERSION,
             ),
         )


### PR DESCRIPTION
## Related Issues and Dependencies

Related to https://github.com/thoth-station/adviser/issues/2180
- [ ] make sure prescriptions-refresh-job creates prescriptions with additional tags/categories in metadata

## This introduces a breaking change

- No

## This should yield a new module release

- Yes

## This Pull Request implements

Compute prescriptions metadata in handlers: 
- prescriptions repository 
- prescriptions version
- last CVE database update for `cve_warning` handler

This list could eventually be expanded depending on the outcome of https://github.com/thoth-station/adviser/issues/2328
