### PR TITLE
Remove destination table from BigQuery config

### DIFF
--- a/thoth/prescriptions_refresh/handlers/pypi_downloads.py
+++ b/thoth/prescriptions_refresh/handlers/pypi_downloads.py
@@ -145,7 +145,6 @@ def pypi_downloads(prescriptions: "Prescriptions") -> None:
     dataset = client.create_dataset(dataset)
 
     job_config = bigquery.QueryJobConfig()
-    job_config.destination = f"{dataset_id_full}.destination_table"
 
     query = f"""
     SELECT *


### PR DESCRIPTION
## This introduces a breaking change

- No

## This should yield a new module release

- Yes

## This Pull Request implements

Remove BigQuery destination table in `pypi-downloads` handler. Writing to a destination table does not seem to have any utility here and might be the source of a lot of traffic generated on the BigQuery API (~6000 calls to the `google.cloud.bigquery.v2.JobService.InsertJob` API method).
