### PR TITLE
Add labels to BigQuery queries

### DIFF
--- a/thoth/prescriptions_refresh/handlers/pypi_downloads.py
+++ b/thoth/prescriptions_refresh/handlers/pypi_downloads.py
@@ -144,7 +144,8 @@ def pypi_downloads(prescriptions: "Prescriptions") -> None:
     dataset = bigquery.Dataset(dataset_id_full)
     dataset = client.create_dataset(dataset)
 
-    job_config = bigquery.QueryJobConfig()
+    job_labels = {"query_target": "pypi-file_downloads"}
+    job_config = bigquery.QueryJobConfig(labels=job_labels)
 
     query = f"""
     SELECT *

--- a/thoth/prescriptions_refresh/handlers/scorecards.py
+++ b/thoth/prescriptions_refresh/handlers/scorecards.py
@@ -868,10 +868,9 @@ def scorecards(prescriptions: "Prescriptions") -> None:
     for project_name, organization, repository in iter_gh_info(prescriptions):
         query = f"""
         SELECT * FROM openssf.scorecardcron.scorecard WHERE Repo="github.com/{organization}/{repository}"
-        AND Date=(SELECT MAX(Date) FROM openssf.scorecardcron.scorecard
-                  WHERE Repo="github.com/{organization}/{repository}")
         AND Date > DATE_ADD(CURRENT_DATE(),
                    interval-{_THOTH_PRESCRIPTIONS_REFRESH_SCORECARD_FRESHNESS_WEEKS} week)
+        ORDER BY Date DESC LIMIT 1
         """
         query_job = client.query(query=query, job_config=job_config)
         query_result = query_job.result()


### PR DESCRIPTION
## Related Issues and Dependencies

Fixes #170

## This introduces a breaking change

- No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## This should yield a new module release

- Yes

## This Pull Request implements

Add [labels](https://cloud.google.com/bigquery/docs/adding-labels#job-label) to the BigQuery query jobs in order to provide more granularity in our view of the costs of these queries per handler.

Also taking the opportunity to edit the query for scorecards to remove the sub-query.

## Description

<!--- Describe your changes in detail -->

The proposed label to add is: `query_target`.

There are currently 2 handlers that use BigQuery, so a different value is assigned to this label in each handler:

- For PyPI dowloads the value is set to `pypi-file_downloads`
- For scorecards the value is set to `openssf-scorecards`